### PR TITLE
chore: ignore description fields in schema

### DIFF
--- a/target_duckdb/db_sync.py
+++ b/target_duckdb/db_sync.py
@@ -84,6 +84,9 @@ def flatten_schema(d, parent_key=[], sep="__", level=0, max_level=0):
 
     for k, v in d["properties"].items():
         new_key = flatten_key(k, parent_key, sep)
+        # some schemas from airbyte sources have description field which is not needed and causes issues
+        if "description" in v.keys():
+            del v["description"]
         if "type" in v.keys():
             if "object" in v["type"] and "properties" in v and level < max_level:
                 items.extend(
@@ -149,9 +152,6 @@ def flatten_record(
     items = []
     for k, v in d.items():
         new_key = flatten_key(k, parent_key, sep)
-        # some schemas from airbyte sources have description field which is not needed and causes issues
-        if "description" in v.keys():
-            del v["description"]
         if isinstance(v, collections.abc.MutableMapping) and level < max_level:
             items.extend(
                 flatten_record(

--- a/target_duckdb/db_sync.py
+++ b/target_duckdb/db_sync.py
@@ -149,6 +149,9 @@ def flatten_record(
     items = []
     for k, v in d.items():
         new_key = flatten_key(k, parent_key, sep)
+        # some schemas from airbyte sources have description field which is not needed and causes issues
+        if "description" in v.keys():
+            del v["description"]
         if isinstance(v, collections.abc.MutableMapping) and level < max_level:
             items.extend(
                 flatten_record(


### PR DESCRIPTION
Some airbyte sources are now returning description fields in the schema which 1) we don't need and 2) messes up the schema flattening:
https://github.com/airbytehq/airbyte/blob/7c2e51e6999f835e63b964f3e76a657c4d11f57a/airbyte-integrations/connectors/source-intercom/source_intercom/manifest.yaml#L87

We ignore them here in the flatten_schema function